### PR TITLE
Fix flickering when dragging slider on Dell U2412M

### DIFF
--- a/BrightnessMenulet/MainMenuController.m
+++ b/BrightnessMenulet/MainMenuController.m
@@ -94,7 +94,10 @@
 }
 
 - (void)sliderUpdate:(NSSlider*)slider {
-    [[controls screenForDisplayID:slider.tag] setBrightness:[slider integerValue] byOutlet:slider];
+    NSEvent *currentEvent = [[NSApplication sharedApplication] currentEvent];
+    if (currentEvent.type == NSEventTypeLeftMouseUp) {
+        [[controls screenForDisplayID:slider.tag] setBrightness:[slider integerValue] byOutlet:slider];
+    }
 }
 
 - (IBAction)quit:(id)sender {


### PR DESCRIPTION
Application works well with Asus VW202NR.
But when adjusting brightness slider on Dell U2412M, the brightness is flickering. 
This is a dirty workaround to avoid this flickering.